### PR TITLE
Dual Grid View Implementation

### DIFF
--- a/src/DualGridView.ts
+++ b/src/DualGridView.ts
@@ -5,6 +5,7 @@ export class DualGridView {
   private group: Konva.Group;
   private leftGridView: GridView;
   private rightGridView: GridView;
+  private modeLabel: Konva.Text;
 
   constructor(leftGrid: GridView, rightGrid: GridView) {
     this.leftGridView = leftGrid;
@@ -26,12 +27,21 @@ export class DualGridView {
         height: window.innerHeight
     });
 
+    this.modeLabel = new Konva.Text({
+        text: 'Current Mode: ' + this.leftGridView.getVimGrid().getMode(),
+        fontSize: 20,
+        fill: 'blue',
+        x: window.innerWidth / 200, // Position relative to the group's origin
+        y: window.innerHeight * 97/100
+    });
+
     // Add the inner grid groups directly to this group
     leftGroup.add(this.leftGridView.getGroup());
     rightGroup.add(this.rightGridView.getGroup());
 
     this.group.add(leftGroup);
     this.group.add(rightGroup);
+    this.group.add(this.modeLabel);
     
   }
 
@@ -45,5 +55,14 @@ export class DualGridView {
 
   getRightGridView(): GridView {
     return this.rightGridView;
+  }
+
+  private buildModeLabel() {
+    return 'Current Mode: ' + this.leftGridView.getVimGrid().getMode();
+  }
+
+  updateModeLabel() {
+    this.modeLabel.text(this.buildModeLabel());
+    this.modeLabel.getLayer()?.draw();
   }
 }

--- a/src/GridView.ts
+++ b/src/GridView.ts
@@ -213,5 +213,9 @@ export class GridView {
     getGroup(): Konva.Group {
         return this.group;
     }
+
+    getVimGrid(): VimGrid {
+        return this.grid;
+    }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ function handleKeyPress(event: KeyboardEvent) {
   
   // Update the view after handling input
   leftView.update(leftGrid);
+  dualView?.updateModeLabel();
   const cursor = leftGrid.getCursor();
   leftView.setCursor(cursor.row, cursor.col);
 }


### PR DESCRIPTION
Implemented a Dual Grid View
- Introduced a new `DualGridView` class which includes a left and right single view (the left is for typing and the right is the reference view)
- Integrated this functionality into the main game state which now uses the `leftView` for all input handling

Bug Fix:
- Fixed the issue where the cursor disappears off the screen